### PR TITLE
fix: Update CBA description from Cilium to Backstage in PDF index

### DIFF
--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -64,7 +64,7 @@ jobs:
         - [CCA Study Guide](CCA_Study_Guide.pdf) - Cilium Certified Associate
         - [CAPA Study Guide](CAPA_Study_Guide.pdf) - Argo CD Certified Professional - Application Delivery
         - [CGOA Study Guide](CGOA_Study_Guide.pdf) - Certified GitOps Professional
-        - [CBA Study Guide](CBA_Study_Guide.pdf) - Cilium Certified Associate - (Beta)
+        - [CBA Study Guide](CBA_Study_Guide.pdf) - Certified Backstage Associate
         - [OTCA Study Guide](OTCA_Study_Guide.pdf) - OpenTelemetry Certified Associate
         - [KCA Study Guide](KCA_Study_Guide.pdf) - Kyverno Certified Associate
         - [CNPA Study Guide](CNPA_Study_Guide.pdf) - Cloud Native Professional Associate


### PR DESCRIPTION
- Changed 'Cilium Certified Associate - (Beta)' to 'Certified Backstage Associate'
- Ensures consistency with the CBA demo exam changes