### PR TITLE
fix(ci): Add permissions for GitHub Pages deployment

### DIFF
--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -11,6 +11,10 @@ on:
       - '!**/SECURITY.md'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   generate-pdfs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add contents: write and pages: write permissions to workflow
- Fixes 403 permission error when github-actions[bot] tries to push to gh-pages branch
- Resolves workflow run failure #22380120360